### PR TITLE
Adding a Horizontal Scroll Bar for the Main Table

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
             </select>
         </form>
         <br>
+	<div style="overflow-x:auto;">
         <table class="main-table">
             <thead>
                 <tr>
@@ -67,6 +68,7 @@
                 </tr>
             </tbody>
         </table>
+	</div>
         <br>
         <button type="button" class="add-btn">Add Process</button>
         <button type="button" class="remove-btn">Delete Process</button>


### PR DESCRIPTION
Before this change, when the window size was changed to have a horizontal size smaller than the main table, the table wouldn't resize itself in any way to be able to appear on the screen.
After this change, when the window size is changed to have a horizontal size smaller than the main table, the table will have a horizontal scroll bar that can be used to view any parts of the table that can't be viewed in the window at one time.